### PR TITLE
Update filters to use binding rather than events

### DIFF
--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -2,7 +2,7 @@
     export let data;
 </script>
 
-<li>
+<div class="card">
     <span class="status">
         {#if data.completed}
             <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M10 19.993c5.523 0 10-4.474 10-9.993C20 4.48 15.523.007 10 .007S0 4.48 0 10c0 5.52 4.477 9.993 10 9.993z" fill="#32BEA6"/><path d="M9.198 15.316L4.47 11.632l1.344-1.725 2.904 2.262 4.792-6.915L15.308 6.5l-6.11 8.816z" fill="#fff"/></svg>
@@ -11,10 +11,10 @@
         {/if}
     </span>
     <span class="title { data.completed ? 'completed' : '' }">{ data.title }</span>
-</li>
+</div>
 
 <style>
-    li {
+    .card {
         align-items: flex-start;
         display: flex;
         margin-bottom: .5rem;

--- a/src/components/Filters.svelte
+++ b/src/components/Filters.svelte
@@ -1,18 +1,10 @@
 <script>
-    import { createEventDispatcher } from 'svelte';
-
-    const dispatch = createEventDispatcher();
-
-    let selected = 'all';
-    
-    function updateFilter(event) {
-        dispatch('updatefilter', selected);
-    }
+    export let selected = 'all';
 </script>
 
 <div>
 	<label for="filter">Filter:</label>
-    <select id="filter" bind:value={ selected } on:change={ updateFilter }>
+    <select id="filter" bind:value={ selected }>
         <option value="all">All</option>
         <option value="incomplete">Incomplete</option>
         <option value="complete">Complete</option>

--- a/src/components/Listings.svelte
+++ b/src/components/Listings.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { slide } from 'svelte/transition';
     import Card from './Card.svelte';
 	import Filters from './Filters.svelte';
 
@@ -17,7 +18,9 @@
 <Filters bind:selected />
 
 <ul>
-    {#each filteredContent as todo}
-        <Card data={ todo } />
+    {#each filteredContent as todo (todo.id)}
+        <li transition:slide>
+			<Card data={ todo } />
+		</li>
     {/each}
 </ul>

--- a/src/components/Listings.svelte
+++ b/src/components/Listings.svelte
@@ -1,25 +1,20 @@
 <script>
     import Card from './Card.svelte';
-    import Filters from './Filters.svelte';
+	import Filters from './Filters.svelte';
 
-    export let todos;
-    export let filteredContent = todos;
+	export let todos;
 
-    function filterData(event) {
-        // Show all data
-        if (event.detail === 'all') {
-            filteredContent = todos;
-        // Only show completed items
-        } else if (event.detail === 'complete') {
-            filteredContent = todos.filter(item => item.completed);
-        // Only show incomplete items
-        } else {
-            filteredContent = todos.filter(item => !item.completed);
-        }
-    }
+	const filters = {
+		all: () => true,
+		complete: ({ completed }) => completed,
+		incomplete: ({ completed }) => !completed
+	};
+
+	let selected = 'all';
+	$: filteredContent = todos.filter(filters[selected]);
 </script>
 
-<Filters on:updatefilter={ filterData } />
+<Filters bind:selected />
 
 <ul>
     {#each filteredContent as todo}


### PR DESCRIPTION
I thought your article was great, but the filter implementation stood out to me as not quite the Svelte way. Binding the value reduces the amount of code you have to write and gives you the ability to set the initial value from the parent.

If you wanted to stick with the event-driven way, there is also a shortcut available:

```svelte
<select id="filter" on:change>
```

and then:

```svelte
<Filters on:change={filterData} />
```

Then Svelte will forward the DOM event up to the parent where you can then use the value to update the list of todos.

I also added in some transitions since Svelte makes them so easy 😄.